### PR TITLE
Fixed jQuery selector, added single quotes

### DIFF
--- a/src/jquery.hash-tabs.js
+++ b/src/jquery.hash-tabs.js
@@ -246,7 +246,7 @@
        */
 
       HashTabs.prototype.triggerTab = function(url) {
-        return this.$tabButtons.filter("[href*=" + url + "]").trigger("click");
+        return this.$tabButtons.filter("[href*='" + url + "']").trigger("click");
       };
 
 


### PR DESCRIPTION
Added single quotes to jQuery selector.
Broken selector made tabs broken when a hash was given in the url on page load to set current active tab.
